### PR TITLE
extract frontend config and css

### DIFF
--- a/app/components/ChatPreview.css
+++ b/app/components/ChatPreview.css
@@ -1,0 +1,9 @@
+.messages-area {
+  height: calc(100% - 160px);
+  overflow-y: auto;
+}
+
+.input-area {
+  position: absolute;
+  bottom: 20px;
+}

--- a/app/components/ChatPreview.js
+++ b/app/components/ChatPreview.js
@@ -1,6 +1,7 @@
 "use client";
 import React, { useRef, useState, useEffect } from "react";
 import { Menu, Send, User, Bot } from "lucide-react";
+import "./ChatPreview.css";
 
 const ChatPreview = ({
   config,
@@ -155,8 +156,6 @@ const ChatPreview = ({
               border: `1px solid ${currentTheme.colors.border}`,
               borderRadius: currentTheme.spacing.borderRadius,
               padding: currentTheme.spacing.containerPadding,
-              height: "calc(100% - 160px)",
-              overflowY: "auto",
               marginTop: config.menuPosition.position === "top" ? "80px" : "20px",
               marginBottom: "20px",
             }}
@@ -197,8 +196,6 @@ const ChatPreview = ({
           <div
             className="input-area flex gap-2"
             style={{
-              position: "absolute",
-              bottom: "20px",
               left: currentTheme.spacing.containerPadding,
               right: currentTheme.spacing.containerPadding,
             }}

--- a/app/page.js
+++ b/app/page.js
@@ -2,100 +2,12 @@
 import React, { useState } from 'react';
 import ChatPreview from './components/ChatPreview';
 import ConfigPanel from './components/ConfigPanel';
+import initialConfig from '../config/chatConfig.json' assert { type: 'json' };
 
 const ChatFrontendGenerator = () => {
-  const [config, setConfig] = useState({
-    menuPosition: {
-      type: 'fixed',
-      position: 'left',
-      coordinates: { x: 0, y: 0 }
-    },
-    textInput: {
-      width: '100%',
-      height: '50px'
-    },
-    themes: ['modern', 'classic', 'minimal'],
-    defaultTheme: 'modern',
-    themeConfigs: {
-      modern: {
-        colors: {
-          background: '#0f0f23',
-          chatBackground: '#1a1a2e',
-          userMessage: '#2d4a88',
-          aiMessage: '#333366',
-          text: '#ffffff',
-          textSecondary: '#b0b0b0',
-          menuBackground: '#16213e',
-          border: '#3d4a6b',
-          accent: '#4f7cff'
-        },
-        typography: {
-          fontFamily: 'Inter, system-ui, sans-serif',
-          fontSize: '14px',
-          fontWeight: '400',
-          lineHeight: '1.5'
-        },
-        spacing: {
-          messagePadding: '12px 16px',
-          messageMargin: '8px 0',
-          containerPadding: '20px',
-          borderRadius: '12px'
-        }
-      },
-      classic: {
-        colors: {
-          background: '#f5f5f5',
-          chatBackground: '#ffffff',
-          userMessage: '#007bff',
-          aiMessage: '#e9ecef',
-          text: '#333333',
-          textSecondary: '#666666',
-          menuBackground: '#ffffff',
-          border: '#dee2e6',
-          accent: '#007bff'
-        },
-        typography: {
-          fontFamily: 'Arial, sans-serif',
-          fontSize: '14px',
-          fontWeight: '400',
-          lineHeight: '1.4'
-        },
-        spacing: {
-          messagePadding: '10px 15px',
-          messageMargin: '5px 0',
-          containerPadding: '15px',
-          borderRadius: '8px'
-        }
-      },
-      minimal: {
-        colors: {
-          background: '#ffffff',
-          chatBackground: '#ffffff',
-          userMessage: '#000000',
-          aiMessage: '#f8f9fa',
-          text: '#000000',
-          textSecondary: '#666666',
-          menuBackground: '#ffffff',
-          border: '#e0e0e0',
-          accent: '#000000'
-        },
-        typography: {
-          fontFamily: 'SF Pro Display, -apple-system, sans-serif',
-          fontSize: '15px',
-          fontWeight: '400',
-          lineHeight: '1.6'
-        },
-        spacing: {
-          messagePadding: '16px 20px',
-          messageMargin: '12px 0',
-          containerPadding: '24px',
-          borderRadius: '20px'
-        }
-      }
-    }
-  });
+  const [config, setConfig] = useState(initialConfig);
 
-  const [activeTheme, setActiveTheme] = useState('modern');
+  const [activeTheme, setActiveTheme] = useState(initialConfig.defaultTheme);
   const [sampleMessages] = useState([
     { type: 'user', content: 'Hola, ¿cómo estás?' },
     { type: 'ai', content: '¡Hola! Estoy muy bien, gracias por preguntar. ¿En qué puedo ayudarte hoy?' },

--- a/config/chatConfig.json
+++ b/config/chatConfig.json
@@ -1,0 +1,90 @@
+{
+  "menuPosition": {
+    "type": "fixed",
+    "position": "left",
+    "coordinates": { "x": 0, "y": 0 }
+  },
+  "textInput": {
+    "width": "100%",
+    "height": "50px"
+  },
+  "themes": ["modern", "classic", "minimal"],
+  "defaultTheme": "modern",
+  "themeConfigs": {
+    "modern": {
+      "colors": {
+        "background": "#0f0f23",
+        "chatBackground": "#1a1a2e",
+        "userMessage": "#2d4a88",
+        "aiMessage": "#333366",
+        "text": "#ffffff",
+        "textSecondary": "#b0b0b0",
+        "menuBackground": "#16213e",
+        "border": "#3d4a6b",
+        "accent": "#4f7cff"
+      },
+      "typography": {
+        "fontFamily": "Inter, system-ui, sans-serif",
+        "fontSize": "14px",
+        "fontWeight": "400",
+        "lineHeight": "1.5"
+      },
+      "spacing": {
+        "messagePadding": "12px 16px",
+        "messageMargin": "8px 0",
+        "containerPadding": "20px",
+        "borderRadius": "12px"
+      }
+    },
+    "classic": {
+      "colors": {
+        "background": "#f5f5f5",
+        "chatBackground": "#ffffff",
+        "userMessage": "#007bff",
+        "aiMessage": "#e9ecef",
+        "text": "#333333",
+        "textSecondary": "#666666",
+        "menuBackground": "#ffffff",
+        "border": "#dee2e6",
+        "accent": "#007bff"
+      },
+      "typography": {
+        "fontFamily": "Arial, sans-serif",
+        "fontSize": "14px",
+        "fontWeight": "400",
+        "lineHeight": "1.4"
+      },
+      "spacing": {
+        "messagePadding": "10px 15px",
+        "messageMargin": "5px 0",
+        "containerPadding": "15px",
+        "borderRadius": "8px"
+      }
+    },
+    "minimal": {
+      "colors": {
+        "background": "#ffffff",
+        "chatBackground": "#ffffff",
+        "userMessage": "#000000",
+        "aiMessage": "#f8f9fa",
+        "text": "#000000",
+        "textSecondary": "#666666",
+        "menuBackground": "#ffffff",
+        "border": "#e0e0e0",
+        "accent": "#000000"
+      },
+      "typography": {
+        "fontFamily": "SF Pro Display, -apple-system, sans-serif",
+        "fontSize": "15px",
+        "fontWeight": "400",
+        "lineHeight": "1.6"
+      },
+      "spacing": {
+        "messagePadding": "16px 20px",
+        "messageMargin": "12px 0",
+        "containerPadding": "24px",
+        "borderRadius": "20px"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- move ChatFrontendGenerator default configuration to `config/chatConfig.json`
- add `ChatPreview.css` for static styles
- load config from json and import new css

## Testing
- `npm run lint` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687c22d3ef388332a5015e686490d8ef