### PR TITLE
Make fixed menu fill page height

### DIFF
--- a/app/components/ChatPreview.js
+++ b/app/components/ChatPreview.js
@@ -15,6 +15,8 @@ const ChatPreview = ({
   const menuRef = useRef(null);
   const chatContainerRef = useRef(null);
 
+  const MENU_WIDTH = 200;
+
   const handleMenuDragStart = (e) => {
     if (config.menuPosition.type !== "draggable") return;
 
@@ -60,6 +62,11 @@ const ChatPreview = ({
     }
   }, [isDraggingMenu]);
 
+  const isFixedLeftRight =
+    config.menuPosition.type === "fixed" &&
+    (config.menuPosition.position === "left" ||
+      config.menuPosition.position === "right");
+
   const getMenuStyle = () => {
     const baseStyle = {
       backgroundColor: currentTheme.colors.menuBackground,
@@ -83,9 +90,25 @@ const ChatPreview = ({
 
     switch (config.menuPosition.position) {
       case "left":
-        return { ...baseStyle, position: "absolute", left: "20px", top: "20px" };
+        return {
+          ...baseStyle,
+          position: "absolute",
+          left: 0,
+          top: 0,
+          bottom: 0,
+          height: "100%",
+          width: `${MENU_WIDTH}px`,
+        };
       case "right":
-        return { ...baseStyle, position: "absolute", right: "20px", top: "20px" };
+        return {
+          ...baseStyle,
+          position: "absolute",
+          right: 0,
+          top: 0,
+          bottom: 0,
+          height: "100%",
+          width: `${MENU_WIDTH}px`,
+        };
       case "top":
         return {
           ...baseStyle,
@@ -122,6 +145,14 @@ const ChatPreview = ({
             fontSize: currentTheme.typography.fontSize,
             color: currentTheme.colors.text,
             padding: currentTheme.spacing.containerPadding,
+            ...(isFixedLeftRight &&
+              config.menuPosition.position === "left" && {
+                paddingLeft: `calc(${currentTheme.spacing.containerPadding} + ${MENU_WIDTH}px)`,
+              }),
+            ...(isFixedLeftRight &&
+              config.menuPosition.position === "right" && {
+                paddingRight: `calc(${currentTheme.spacing.containerPadding} + ${MENU_WIDTH}px)`,
+              }),
           }}
         >
           {/* Menú */}
@@ -195,10 +226,16 @@ const ChatPreview = ({
           {/* Input de texto */}
           <div
             className="input-area flex gap-2"
-            style={{
-              left: currentTheme.spacing.containerPadding,
-              right: currentTheme.spacing.containerPadding,
-            }}
+          style={{
+            left:
+              isFixedLeftRight && config.menuPosition.position === "left"
+                ? `calc(${currentTheme.spacing.containerPadding} + ${MENU_WIDTH}px)`
+                : currentTheme.spacing.containerPadding,
+            right:
+              isFixedLeftRight && config.menuPosition.position === "right"
+                ? `calc(${currentTheme.spacing.containerPadding} + ${MENU_WIDTH}px)`
+                : currentTheme.spacing.containerPadding,
+          }}
           >
             <input
               type="text"

--- a/app/page.js
+++ b/app/page.js
@@ -43,6 +43,8 @@ const ChatFrontendGenerator = () => {
   background-color: ${theme.colors.background};
   color: ${theme.colors.text};
   padding: ${theme.spacing.containerPadding};
+  ${config.menuPosition.type === 'fixed' && config.menuPosition.position === 'left' ? `padding-left: calc(${theme.spacing.containerPadding} + 200px);` : ''}
+  ${config.menuPosition.type === 'fixed' && config.menuPosition.position === 'right' ? `padding-right: calc(${theme.spacing.containerPadding} + 200px);` : ''}
   height: 100vh;
   position: relative;
 }
@@ -101,8 +103,10 @@ const ChatFrontendGenerator = () => {
 
   const getMenuPositionCSS = () => {
     switch (config.menuPosition.position) {
-      case 'left': return 'position: fixed; left: 20px; top: 20px; width: 200px;';
-      case 'right': return 'position: fixed; right: 20px; top: 20px; width: 200px;';
+      case 'left':
+        return 'position: fixed; left: 0; top: 0; bottom: 0; width: 200px; height: 100vh;';
+      case 'right':
+        return 'position: fixed; right: 0; top: 0; bottom: 0; width: 200px; height: 100vh;';
       case 'top': return 'position: fixed; top: 20px; left: 50%; transform: translateX(-50%);';
       case 'bottom': return 'position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);';
       default: return 'position: fixed; left: 20px; top: 20px;';


### PR DESCRIPTION
## Summary
- adjust `ChatPreview` styling so fixed menu spans full column
- offset chat container and input when menu is left or right
- update exported CSS logic in `page.js`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from `fonts.gstatic.com`)*

------
https://chatgpt.com/codex/tasks/task_e_687c242a73d48332ad8ca4561d50aefc