### PR TITLE
Improve chat UI and theme management

### DIFF
--- a/app/components/ChatPreview.js
+++ b/app/components/ChatPreview.js
@@ -127,7 +127,7 @@ const ChatPreview = ({
         return {
           ...baseStyle,
           position: "absolute",
-          bottom: "80px",
+          bottom: "20px",
           left: "50%",
           transform: "translateX(-50%)",
         };
@@ -208,8 +208,13 @@ const ChatPreview = ({
                   display: "flex",
                   justifyContent: message.type === "user" ? "flex-end" : "flex-start",
                   margin: currentTheme.spacing.messageMargin,
+                  alignItems: "flex-end",
+                  gap: "4px",
                 }}
               >
+                {message.type === "user" && (
+                  <User size={16} style={{ marginRight: "4px" }} />
+                )}
                 <div
                   style={{
                     backgroundColor:
@@ -220,15 +225,13 @@ const ChatPreview = ({
                     padding: currentTheme.spacing.messagePadding,
                     borderRadius: currentTheme.spacing.borderRadius,
                     maxWidth: "80%",
-                    display: "flex",
-                    alignItems: "flex-start",
-                    gap: "8px",
                   }}
                 >
-                  {message.type === "ai" && <Bot size={16} />}
-                  {message.type === "user" && <User size={16} />}
                   <span>{message.content}</span>
                 </div>
+                {message.type === "ai" && (
+                  <Bot size={16} style={{ marginLeft: "4px" }} />
+                )}
               </div>
             ))}
           </div>
@@ -245,6 +248,7 @@ const ChatPreview = ({
               isFixedLeftRight && config.menuPosition.position === "right"
                 ? `calc(${currentTheme.spacing.containerPadding} + ${MENU_WIDTH}px)`
                 : currentTheme.spacing.containerPadding,
+            bottom: config.menuPosition.position === "bottom" ? "80px" : "20px",
           }}
           >
             <input

--- a/app/components/ConfigPanel.js
+++ b/app/components/ConfigPanel.js
@@ -11,6 +11,24 @@ const ConfigPanel = ({
   updateThemeConfig,
   exportConfig,
 }) => {
+  const addTheme = () => {
+    const name = prompt("Nombre del nuevo tema");
+    if (!name) return;
+    if (config.themes.includes(name)) {
+      alert("El tema ya existe");
+      return;
+    }
+    const baseTheme = config.themeConfigs[activeTheme];
+    setConfig((prev) => ({
+      ...prev,
+      themes: [...prev.themes, name],
+      themeConfigs: {
+        ...prev.themeConfigs,
+        [name]: JSON.parse(JSON.stringify(baseTheme)),
+      },
+    }));
+    setActiveTheme(name);
+  };
   return (
     <div className="w-80 bg-white border-l overflow-y-auto">
       <div className="p-4 border-b bg-gray-50">
@@ -24,18 +42,25 @@ const ConfigPanel = ({
         {/* Selector de Tema */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-2">Tema Activo</label>
-          <select
-            value={activeTheme}
-            onChange={(e) => setActiveTheme(e.target.value)}
-            className="w-full p-2 border border-gray-300 rounded-md"
-          >
-            {config.themes.map((theme) => (
-              <option key={theme} value={theme}>
-                {theme}
-              </option>
-            ))}
-          </select>
-        </div>
+        <select
+          value={activeTheme}
+          onChange={(e) => setActiveTheme(e.target.value)}
+          className="w-full p-2 border border-gray-300 rounded-md"
+        >
+          {config.themes.map((theme) => (
+            <option key={theme} value={theme}>
+              {theme}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={addTheme}
+          className="mt-2 text-sm text-blue-600"
+        >
+          Nuevo Tema
+        </button>
+      </div>
 
         {/* Configuración de Menú */}
         <div>

--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ChatPreview from './components/ChatPreview';
 import ConfigPanel from './components/ConfigPanel';
 import initialConfig from '../config/chatConfig.json' assert { type: 'json' };
@@ -14,6 +14,21 @@ const ChatFrontendGenerator = () => {
     { type: 'user', content: 'Me gustaría saber más sobre inteligencia artificial' },
     { type: 'ai', content: 'La inteligencia artificial es un campo fascinante que abarca muchas áreas, desde el machine learning hasta el procesamiento de lenguaje natural. ¿Hay algún aspecto específico que te interese más?' }
   ]);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('chat-config');
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        setConfig(parsed);
+        setActiveTheme(parsed.defaultTheme);
+      } catch (e) {}
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('chat-config', JSON.stringify(config));
+  }, [config]);
 
   const currentTheme = config.themeConfigs[activeTheme];
 


### PR DESCRIPTION
## Summary
- tweak bottom menu so it appears below the input field
- move user and bot icons outside the chat bubbles
- allow creating new themes in the configuration panel
- persist configuration in `localStorage`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c3143c8d08332ad53025fc350e5bb