### PR TITLE
Add theme-aware config panel and modal theme creation

### DIFF
--- a/app/components/ChatPreview.css
+++ b/app/components/ChatPreview.css
@@ -5,5 +5,4 @@
 
 .input-area {
   position: absolute;
-  bottom: 20px;
 }

--- a/app/components/ChatPreview.js
+++ b/app/components/ChatPreview.js
@@ -240,17 +240,11 @@ const ChatPreview = ({
           {/* Input de texto */}
           <div
             className="input-area flex gap-2"
-          style={{
-            left:
-              isFixedLeftRight && config.menuPosition.position === "left"
-                ? `calc(${currentTheme.spacing.containerPadding} + ${MENU_WIDTH}px)`
-                : currentTheme.spacing.containerPadding,
-            right:
-              isFixedLeftRight && config.menuPosition.position === "right"
-                ? `calc(${currentTheme.spacing.containerPadding} + ${MENU_WIDTH}px)`
-                : currentTheme.spacing.containerPadding,
-            bottom: config.menuPosition.position === "bottom" ? "85px" : "40px",
-          }}
+            style={{
+              bottom: config.menuPosition.position === "bottom" ? "85px" : "40px",
+              left: "50%",
+              transform: "translateX(-50%)",
+            }}
           >
             <input
               type="text"

--- a/app/components/ConfigPanel.js
+++ b/app/components/ConfigPanel.js
@@ -1,6 +1,7 @@
 "use client";
-import React from "react";
+import React, { useState } from "react";
 import { Download, Palette, Type, Layout, Settings } from "lucide-react";
+import Modal from "./Modal";
 
 const ConfigPanel = ({
   config,
@@ -11,11 +12,23 @@ const ConfigPanel = ({
   updateThemeConfig,
   exportConfig,
 }) => {
+  const [showAddThemeModal, setShowAddThemeModal] = useState(false);
+  const [newThemeName, setNewThemeName] = useState("");
+  const [themeError, setThemeError] = useState("");
+
   const addTheme = () => {
-    const name = prompt("Nombre del nuevo tema");
-    if (!name) return;
+    setThemeError("");
+    setShowAddThemeModal(true);
+  };
+
+  const confirmAddTheme = () => {
+    const name = newThemeName.trim();
+    if (!name) {
+      setThemeError("Debe ingresar un nombre");
+      return;
+    }
     if (config.themes.includes(name)) {
-      alert("El tema ya existe");
+      setThemeError("El tema ya existe");
       return;
     }
     const baseTheme = config.themeConfigs[activeTheme];
@@ -28,15 +41,24 @@ const ConfigPanel = ({
       },
     }));
     setActiveTheme(name);
+    setNewThemeName("");
+    setShowAddThemeModal(false);
   };
   return (
-    <div className="w-80 bg-white border-l overflow-y-auto">
-      <div className="p-4 border-b bg-gray-50">
-        <h2 className="text-lg font-semibold text-gray-800 flex items-center gap-2">
-          <Settings size={20} />
-          Configuración
-        </h2>
-      </div>
+    <>
+      <div
+        className="w-80 border-l overflow-y-auto"
+        style={{ backgroundColor: currentTheme.colors.chatBackground }}
+      >
+        <div
+          className="p-4 border-b"
+          style={{ backgroundColor: currentTheme.colors.background }}
+        >
+          <h2 className="text-lg font-semibold text-gray-800 flex items-center gap-2">
+            <Settings size={20} />
+            Configuración
+          </h2>
+        </div>
 
       <div className="p-4 space-y-6">
         {/* Selector de Tema */}
@@ -226,7 +248,39 @@ const ConfigPanel = ({
           Exportar Configuración
         </button>
       </div>
-    </div>
+      </div>
+      <Modal
+        isOpen={showAddThemeModal}
+        title="Nuevo Tema"
+        onClose={() => setShowAddThemeModal(false)}
+        currentTheme={currentTheme}
+      >
+        <div className="space-y-4">
+          <input
+            type="text"
+            value={newThemeName}
+            onChange={(e) => setNewThemeName(e.target.value)}
+            className="w-full p-2 border border-gray-300 rounded"
+            placeholder="Nombre del tema"
+          />
+          {themeError && <p className="text-sm text-red-600">{themeError}</p>}
+          <div className="flex justify-end gap-2">
+            <button
+              className="px-4 py-2 text-sm border rounded"
+              onClick={() => setShowAddThemeModal(false)}
+            >
+              Cancelar
+            </button>
+            <button
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded"
+              onClick={confirmAddTheme}
+            >
+              Guardar
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </>
   );
 };
 

--- a/app/components/Modal.js
+++ b/app/components/Modal.js
@@ -1,0 +1,19 @@
+"use client";
+import React from "react";
+
+const Modal = ({ isOpen, title, children, onClose, currentTheme }) => {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-20" style={{ backgroundColor: "rgba(0,0,0,0.5)" }}>
+      <div className="rounded-lg p-4 w-80 max-w-full" style={{ backgroundColor: currentTheme.colors.chatBackground, color: currentTheme.colors.text }}>
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <button onClick={onClose} className="text-2xl leading-none">&times;</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;


### PR DESCRIPTION
## Summary
- create Modal component for input forms
- theme colors control config panel background
- center the chat input bar
- add modal workflow for creating themes

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from https://fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_687c363a83cc8332917768fae342cb59