### PR TITLE
Refactor chat preview into smaller components

### DIFF
--- a/app/components/ChatInput.js
+++ b/app/components/ChatInput.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { Send } from "lucide-react";
+
+const ChatInput = ({ config, currentTheme }) => {
+  return (
+    <div
+      className="input-area flex gap-2"
+      style={{
+        bottom: config.menuPosition.position === "bottom" ? "85px" : "40px",
+        left: "50%",
+        transform: "translateX(-50%)",
+      }}
+    >
+      <input
+        type="text"
+        placeholder="Escribe tu mensaje aquí..."
+        style={{
+          width: config.textInput.width,
+          height: config.textInput.height,
+          padding: "12px 16px",
+          border: `1px solid ${currentTheme.colors.border}`,
+          borderRadius: currentTheme.spacing.borderRadius,
+          backgroundColor: currentTheme.colors.chatBackground,
+          color: currentTheme.colors.text,
+          fontFamily: "inherit",
+          fontSize: "inherit",
+          outline: "none",
+        }}
+      />
+      <button
+        style={{
+          backgroundColor: currentTheme.colors.accent,
+          color: "white",
+          border: "none",
+          borderRadius: currentTheme.spacing.borderRadius,
+          padding: "12px",
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Send size={16} />
+      </button>
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/app/components/ChatMenu.js
+++ b/app/components/ChatMenu.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { Menu } from "lucide-react";
+
+const ChatMenu = ({
+  menuRef,
+  style,
+  onMouseDown,
+  config,
+  currentTheme,
+}) => {
+  return (
+    <div
+      ref={menuRef}
+      style={style}
+      onMouseDown={onMouseDown}
+      className={config.menuPosition.type === "draggable" ? "cursor-move" : ""}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Menu size={16} style={{ color: currentTheme.colors.text }} />
+        <span style={{ color: currentTheme.colors.text, fontSize: "14px" }}>Menú</span>
+      </div>
+      <div
+        className={
+          config.menuPosition.position === "top" || config.menuPosition.position === "bottom"
+            ? "flex gap-2"
+            : "space-y-1"
+        }
+      >
+        <div className="px-2 py-1 text-sm rounded" style={{ color: currentTheme.colors.textSecondary }}>
+          Nueva conversación
+        </div>
+        <div className="px-2 py-1 text-sm rounded" style={{ color: currentTheme.colors.textSecondary }}>
+          Historial
+        </div>
+        <div className="px-2 py-1 text-sm rounded" style={{ color: currentTheme.colors.textSecondary }}>
+          Configuración
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatMenu;

--- a/app/components/ChatMessages.js
+++ b/app/components/ChatMessages.js
@@ -1,0 +1,50 @@
+import React from "react";
+import { User, Bot } from "lucide-react";
+
+const ChatMessages = ({ sampleMessages, currentTheme, config }) => {
+  return (
+    <div
+      className="messages-area"
+      style={{
+        backgroundColor: currentTheme.colors.chatBackground,
+        border: `1px solid ${currentTheme.colors.border}`,
+        borderRadius: currentTheme.spacing.borderRadius,
+        padding: currentTheme.spacing.containerPadding,
+        marginTop: config.menuPosition.position === "top" ? "80px" : "20px",
+        marginBottom: "20px",
+      }}
+    >
+      {sampleMessages.map((message, index) => (
+        <div
+          key={index}
+          style={{
+            display: "flex",
+            justifyContent: message.type === "user" ? "flex-end" : "flex-start",
+            margin: currentTheme.spacing.messageMargin,
+            alignItems: "flex-end",
+            gap: "4px",
+          }}
+        >
+          {message.type === "ai" && <Bot size={30} style={{ marginLeft: "4px" }} />}
+          <div
+            style={{
+              backgroundColor:
+                message.type === "user"
+                  ? currentTheme.colors.userMessage
+                  : currentTheme.colors.aiMessage,
+              color: message.type === "user" ? "white" : currentTheme.colors.text,
+              padding: currentTheme.spacing.messagePadding,
+              borderRadius: currentTheme.spacing.borderRadius,
+              maxWidth: "80%",
+            }}
+          >
+            <span>{message.content}</span>
+          </div>
+          {message.type === "user" && <User size={30} style={{ marginRight: "4px" }} />}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ChatMessages;

--- a/app/components/ChatPreview.js
+++ b/app/components/ChatPreview.js
@@ -1,6 +1,8 @@
 "use client";
 import React, { useRef, useState, useEffect } from "react";
-import { Menu, Send, User, Bot } from "lucide-react";
+import ChatMenu from "./ChatMenu";
+import ChatMessages from "./ChatMessages";
+import ChatInput from "./ChatInput";
 import "./ChatPreview.css";
 
 const ChatPreview = ({
@@ -177,123 +179,21 @@ const ChatPreview = ({
               }),
           }}
         >
-          {/* Menú */}
-          <div
-            ref={menuRef}
+          <ChatMenu
+            menuRef={menuRef}
             style={getMenuStyle()}
             onMouseDown={handleMenuDragStart}
-            className={config.menuPosition.type === "draggable" ? "cursor-move" : ""}
-          >
-            <div className="flex items-center gap-2 mb-2">
-              <Menu size={16} style={{ color: currentTheme.colors.text }} />
-              <span style={{ color: currentTheme.colors.text, fontSize: "14px" }}>Menú</span>
-            </div>
-            <div
-              className={
-                config.menuPosition.position === "top" || config.menuPosition.position === "bottom" ? "flex gap-2" : "space-y-1"
-              }
-            >
-              <div className="px-2 py-1 text-sm rounded" style={{ color: currentTheme.colors.textSecondary }}>
-                Nueva conversación
-              </div>
-              <div className="px-2 py-1 text-sm rounded" style={{ color: currentTheme.colors.textSecondary }}>
-                Historial
-              </div>
-              <div className="px-2 py-1 text-sm rounded" style={{ color: currentTheme.colors.textSecondary }}>
-                Configuración
-              </div>
-            </div>
-          </div>
+            config={config}
+            currentTheme={currentTheme}
+          />
 
-          {/* Área de mensajes */}
-          <div
-            className="messages-area"
-            style={{
-              backgroundColor: currentTheme.colors.chatBackground,
-              border: `1px solid ${currentTheme.colors.border}`,
-              borderRadius: currentTheme.spacing.borderRadius,
-              padding: currentTheme.spacing.containerPadding,
-              marginTop: config.menuPosition.position === "top" ? "80px" : "20px",
-              marginBottom: "20px",
-            }}
-          >
-            {sampleMessages.map((message, index) => (
-              <div
-                key={index}
-                style={{
-                  display: "flex",
-                  justifyContent: message.type === "user" ? "flex-end" : "flex-start",
-                  margin: currentTheme.spacing.messageMargin,
-                  alignItems: "flex-end",
-                  gap: "4px",
-                }}
-              >
-                {message.type === "ai" && (
-                  <Bot size={30} style={{ marginLeft: "4px" }} />
-                )}
-                <div
-                  style={{
-                    backgroundColor:
-                      message.type === "user"
-                        ? currentTheme.colors.userMessage
-                        : currentTheme.colors.aiMessage,
-                    color: message.type === "user" ? "white" : currentTheme.colors.text,
-                    padding: currentTheme.spacing.messagePadding,
-                    borderRadius: currentTheme.spacing.borderRadius,
-                    maxWidth: "80%",
-                  }}
-                >
-                  <span>{message.content}</span>
-                </div>
-                {message.type === "user" && (
-                  <User size={30} style={{ marginRight: "4px" }} />
-                )}
+          <ChatMessages
+            sampleMessages={sampleMessages}
+            currentTheme={currentTheme}
+            config={config}
+          />
 
-              </div>
-            ))}
-          </div>
-
-          {/* Input de texto */}
-          <div
-            className="input-area flex gap-2"
-            style={{
-              bottom: config.menuPosition.position === "bottom" ? "85px" : "40px",
-              left: "50%",
-              transform: "translateX(-50%)",
-            }}
-          >
-            <input
-              type="text"
-              placeholder="Escribe tu mensaje aquí..."
-              style={{
-                width: config.textInput.width,
-                height: config.textInput.height,
-                padding: "12px 16px",
-                border: `1px solid ${currentTheme.colors.border}`,
-                borderRadius: currentTheme.spacing.borderRadius,
-                backgroundColor: currentTheme.colors.chatBackground,
-                color: currentTheme.colors.text,
-                fontFamily: "inherit",
-                fontSize: "inherit",
-                outline: "none",
-              }}
-            />
-            <button
-              style={{
-                backgroundColor: currentTheme.colors.accent,
-                color: "white",
-                border: "none",
-                borderRadius: currentTheme.spacing.borderRadius,
-                padding: "12px",
-                cursor: "pointer",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <Send size={16} />
-            </button>
-          </div>
+          <ChatInput config={config} currentTheme={currentTheme} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- break down `ChatPreview` into `ChatMenu`, `ChatMessages` and `ChatInput`
- create new component files for each part

## Testing
- `npm ci`
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_687c46c3ae508332b87e374b0f7cbbc9