### PR TITLE
Add jest setup and sample unit tests

### DIFF
--- a/__tests__/ChatInput.test.js
+++ b/__tests__/ChatInput.test.js
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import ChatInput from '../app/components/ChatInput'
+import config from '../config/chatConfig.json' assert { type: 'json' }
+
+describe('ChatInput', () => {
+  const theme = config.themeConfigs[config.defaultTheme]
+
+  it('renders input placeholder', () => {
+    render(<ChatInput config={config} currentTheme={theme} />)
+    expect(screen.getByPlaceholderText('Escribe tu mensaje aquí...')).toBeInTheDocument()
+  })
+})

--- a/__tests__/ChatMenu.test.js
+++ b/__tests__/ChatMenu.test.js
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import ChatMenu from '../app/components/ChatMenu'
+import React from 'react'
+import config from '../config/chatConfig.json' assert { type: 'json' }
+
+describe('ChatMenu', () => {
+  const theme = config.themeConfigs[config.defaultTheme]
+
+  it('renders menu options', () => {
+    render(<ChatMenu menuRef={React.createRef()} style={{}} onMouseDown={()=>{}} config={config} currentTheme={theme} />)
+    expect(screen.getByText('Menú')).toBeInTheDocument()
+    expect(screen.getByText('Nueva conversación')).toBeInTheDocument()
+  })
+})

--- a/__tests__/ChatMessages.test.js
+++ b/__tests__/ChatMessages.test.js
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import ChatMessages from '../app/components/ChatMessages'
+import config from '../config/chatConfig.json' assert { type: 'json' }
+
+describe('ChatMessages', () => {
+  const theme = config.themeConfigs[config.defaultTheme]
+  const sample = [
+    { type: 'user', content: 'hola' },
+    { type: 'ai', content: 'respuesta' },
+  ]
+
+  it('shows provided messages', () => {
+    render(<ChatMessages sampleMessages={sample} currentTheme={theme} config={config} />)
+    expect(screen.getByText('hola')).toBeInTheDocument()
+    expect(screen.getByText('respuesta')).toBeInTheDocument()
+  })
+})

--- a/__tests__/ChatPreview.test.js
+++ b/__tests__/ChatPreview.test.js
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import ChatPreview from '../app/components/ChatPreview'
+import config from '../config/chatConfig.json' assert { type: 'json' }
+
+describe('ChatPreview', () => {
+  const theme = config.themeConfigs[config.defaultTheme]
+  const sampleMessages = [
+    { type: 'user', content: 'hola' },
+    { type: 'ai', content: 'respuesta' },
+  ]
+
+  it('renders menu, messages and input', () => {
+    render(
+      <ChatPreview
+        config={config}
+        setConfig={() => {}}
+        currentTheme={theme}
+        activeTheme={config.defaultTheme}
+        sampleMessages={sampleMessages}
+      />
+    )
+    expect(screen.getByText('Nueva conversación')).toBeInTheDocument()
+    expect(screen.getByText('hola')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Escribe tu mensaje aquí...')).toBeInTheDocument()
+  })
+})

--- a/__tests__/ConfigPanel.test.js
+++ b/__tests__/ConfigPanel.test.js
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import ConfigPanel from '../app/components/ConfigPanel'
+import configData from '../config/chatConfig.json' assert { type: 'json' }
+
+describe('ConfigPanel', () => {
+  const theme = configData.themeConfigs[configData.defaultTheme]
+  let config
+  beforeEach(() => {
+    config = JSON.parse(JSON.stringify(configData))
+  })
+
+  it('opens add theme modal', () => {
+    render(
+      <ConfigPanel
+        config={config}
+        setConfig={() => {}}
+        activeTheme={config.defaultTheme}
+        setActiveTheme={() => {}}
+        currentTheme={theme}
+        updateThemeConfig={() => {}}
+        exportConfig={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByText('Crear Tema'))
+    expect(screen.getByText('Nuevo Tema')).toBeInTheDocument()
+  })
+})

--- a/__tests__/Modal.test.js
+++ b/__tests__/Modal.test.js
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Modal from '../app/components/Modal'
+import config from '../config/chatConfig.json' assert { type: 'json' }
+
+describe('Modal', () => {
+  const theme = config.themeConfigs[config.defaultTheme]
+
+  it('does not render when closed', () => {
+    const { container } = render(
+      <Modal isOpen={false} title="Test" onClose={() => {}} currentTheme={theme}>
+        <p>content</p>
+      </Modal>
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders content and close button', () => {
+    const handleClose = jest.fn()
+    render(
+      <Modal isOpen={true} title="Test" onClose={handleClose} currentTheme={theme}>
+        <p>content</p>
+      </Modal>
+    )
+    expect(screen.getByText('content')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button'))
+    expect(handleClose).toHaveBeenCalled()
+  })
+})

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = { presets: ['next/babel'] }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest',
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "lucide-react": "^0.525.0",
@@ -17,8 +18,13 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "eslint": "^9",
     "eslint-config-next": "15.4.2",
+    "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.4",
     "tailwindcss": "^4"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest with Babel and jsdom
- add setup file for RTL
- add basic unit tests for React components

## Testing
- `npm test -- -u` *(fails: Cannot find module 'next/babel')*

------
https://chatgpt.com/codex/tasks/task_e_687c4a892b0c8332a323e0641050e8eb