### PR TITLE
Fix SWC error with next/font

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = { presets: ['next/babel'] }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   transform: {
-    '^.+\\.jsx?$': 'babel-jest',
+    '^.+\\.jsx?$': ['babel-jest', { presets: ['next/babel'] }],
   },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',


### PR DESCRIPTION
## Summary
- remove root Babel config so Next.js can use SWC
- inline `next/babel` preset for Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d4e3794c88332a5e64b2b5a4c0967